### PR TITLE
fix: update loading etherscan API Key in hardhat config

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -23,9 +23,7 @@ const config: HardhatUserConfig = {
     deployer: 0,
   },
   etherscan: {
-    apiKey: {
-      sepolia: vars.get("ETHERSCAN_API_KEY", ""),
-    },
+    apiKey: vars.get("ETHERSCAN_API_KEY", ""),
   },
   gasReporter: {
     currency: "USD",


### PR DESCRIPTION
Following https://github.com/zama-ai/fhevm-hardhat-template/issues/11

Was not able to verify using Etherscan as it seems the way we are loading the API key for Etherscan force the hardhat plugin to use the v1 API from Etherscan, which is now deprecated. 

[From the documentation](https://hardhat.org/docs/learn-more/smart-contract-verification#configuration):

> In the previous version of the Etherscan API, you needed a different API key for each chain. With Etherscan V2, a single API key works across all networks.