### PR TITLE
fix: add @fhevm/mock-utils as a devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@fhevm/hardhat-plugin": "^0.3.0-0",
+        "@fhevm/mock-utils": "^0.3.0-0",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.0",
         "@nomicfoundation/hardhat-network-helpers": "^1.1.0",
@@ -1109,7 +1110,6 @@
       "integrity": "sha512-SMCV3ntnMtC4WoAr1ySTh2qdWlhIeu/maGp98rhG8gcObZcmFWvDFkb/mkMk7SAVjsjLVNzaXvOJ7DwabsCGcw==",
       "dev": true,
       "license": "BSD-3-Clause-Clear",
-      "peer": true,
       "peerDependencies": {
         "@zama-fhe/relayer-sdk": "^0.3.0-5",
         "ethers": "^6.1.0",
@@ -1126,7 +1126,6 @@
       "resolved": "https://registry.npmjs.org/@fhevm/solidity/-/solidity-0.9.0.tgz",
       "integrity": "sha512-5vpQ0yWnCxU6KAorRQbVovRGoT7vK+kpyvNUQc7nRhAFZeNblr87JWZ3zSUj9xmehQChZGshzT0tWLkF63GJ+A==",
       "license": "BSD-3-Clause-Clear",
-      "peer": true,
       "dependencies": {
         "encrypted-types": "^0.0.4"
       },
@@ -1534,7 +1533,6 @@
       "integrity": "sha512-7xEaz2X8p47qWIAqtV2z03MmusheHm8bvY2mDlxo9JiT2BgSx59GSdv5+mzwOvsuKDbTij7oqDnwFyYOlHREEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.1.1",
         "lodash.isequal": "^4.5.0"
@@ -2039,7 +2037,6 @@
       "integrity": "sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.15",
         "ts-essentials": "^7.0.1"
@@ -2141,7 +2138,6 @@
       "integrity": "sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2226,7 +2222,6 @@
       "integrity": "sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.3",
         "@typescript-eslint/types": "8.46.3",
@@ -2452,7 +2447,6 @@
       "integrity": "sha512-DIPlN9z5tfSCXqUlhQN2MEv57HmAUHSGV9LPtGs6LWmM7POj6WsMd1hU7Qci4AWPsor7k3IqMfqGGthIvot/DQ==",
       "dev": true,
       "license": "BSD-3-Clause-Clear",
-      "peer": true,
       "dependencies": {
         "commander": "^14.0.0",
         "ethers": "^6.15.0",
@@ -2506,7 +2500,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2587,7 +2580,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3153,7 +3145,6 @@
       "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -3912,8 +3903,7 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/encrypted-types/-/encrypted-types-0.0.4.tgz",
       "integrity": "sha512-f55ccBBUwvqWqr3ymAVOLZ6bzjsSQZlDN0GcKFmzkvTpml4Vm3Y6BCaHhCuW/ctrabTJJ3DFnUsjtFOpokJUaQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/enquirer": {
       "version": "2.4.1",
@@ -4114,7 +4104,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4376,7 +4365,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -5210,7 +5198,6 @@
       "integrity": "sha512-TvFKUPGRaoemeVpnKsXt5I+kVCNrzP2cLwyNUveu0JKf2Q0lzh6LTgVBsWyYPlXAwBzyUQ6fsL98UgyF/QdOfA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethereumjs/util": "^9.1.0",
         "@ethersproject/abi": "^5.1.2",
@@ -5342,7 +5329,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "5.8.0",
         "@ethersproject/abstract-provider": "5.8.0",
@@ -7535,7 +7521,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9341,7 +9326,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9596,7 +9580,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9701,7 +9684,6 @@
       "integrity": "sha512-x/sQYr5w9K7yv3es7jo4KTX05CLxOf7TRWwoHlrjRh8H82G64g+k7VuWPJlgMo6qrjfCulOdfBjiaDtmhFYD/Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prettier": "^2.1.1",
         "debug": "^4.3.1",
@@ -9828,7 +9810,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10306,7 +10287,6 @@
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@fhevm/hardhat-plugin": "^0.3.0-0",
+    "@fhevm/mock-utils": "^0.3.0-0",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.0",
     "@nomicfoundation/hardhat-network-helpers": "^1.1.0",


### PR DESCRIPTION
Tests were failing with `HH801: Plugin @fhevm/hardhat-plugin requires @fhevm/mock-utils` because the dependency was missing. This PR adds `@fhevm/mock-utils@0.3.0-0` as a devDependency so that the Hardhat template tests run correctly out of the box.