### PR TITLE
clarify mocked vs non-mocked runs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ FHEVM protocol by Zama.
 For detailed instructions see:
 [FHEVM Hardhat Quick Start Tutorial](https://docs.zama.ai/protocol/solidity-guides/getting-started/quick-start-tutorial)
 
+## Mocked vs non-mocked runs
+
+At a high level:
+
+- **Mocked runs** execute your contracts against local FHEVM mocks.  
+  They are fast, deterministic, and ideal for unit tests, fuzzing, and coverage.
+- **Non-mocked runs** talk to a real FHEVM backend.  
+  They are closer to production behaviour but slower and require a running backend service.
+
+Use mocked runs for most development workflows, and switch to non-mocked runs only
+when you need to validate integration with the real backend or benchmark end-to-end behaviour.
+
 ### Prerequisites
 
 - **Node.js**: Version 20 or higher


### PR DESCRIPTION
Add a short ‘Mocked vs non-mocked runs’ section to the README. It briefly explains when to use mocked runs for local tests and coverage, and when to use non-mocked runs that talk to a real FHEVM backend for more realistic end-to-end checks.